### PR TITLE
experimental manual diversity controls - do not merge, for discussion only.

### DIFF
--- a/Firmware/Makefile
+++ b/Firmware/Makefile
@@ -77,10 +77,12 @@ all:		build
 #
 # Composite targets for handling actions.
 #
-build:		$(filter build~%,$(TARGETS))
+build:		$(filter build~%,$(TARGETS)) check_code
 install:	$(filter install~%,$(TARGETS))
 clean:		$(filter clean~%,$(TARGETS))
 
+check_code:
+	@./tools/check_code.py
 
 #
 # Composite target for handling the generic actions for each possible combination
@@ -95,7 +97,7 @@ $(TARGETS):
 	@make -f $(product)/product.mk $(action) \
 		BOARD=$(board)
 
-.PHONY:	$(ACTIONS) $(TARGETS)
+.PHONY:	$(ACTIONS) $(TARGETS) check_code
 
 help:
 	@echo ""

--- a/Firmware/Makefile
+++ b/Firmware/Makefile
@@ -72,7 +72,7 @@ TARGETS		 = $(foreach action,$(ACTIONS), \
 			$(foreach product,$(PRODUCTS), \
 				$(action)~$(product)))
 
-all:		build
+all:		build install
 
 #
 # Composite targets for handling actions.

--- a/Firmware/radio/at.c
+++ b/Firmware/radio/at.c
@@ -595,8 +595,11 @@ at_plus(void)
     if (at_num == 1) {
       radio_set_diversity(DIVERSITY_ANT1);
     }
-    else {
+    else if (at_num == 2) {
       radio_set_diversity(DIVERSITY_ANT2);
+    }
+    else {
+      radio_set_diversity(DIVERSITY_ENABLED);
     }
     at_ok();
     return;

--- a/Firmware/radio/at.c
+++ b/Firmware/radio/at.c
@@ -598,7 +598,13 @@ at_plus(void)
     else if (at_num == 2) {
       radio_set_diversity(DIVERSITY_ANT2);
     }
-    else {
+    else if (at_num == 3) {
+      feature_diversity == DIVERSITY_TX1_RX2;
+    }
+    else if (at_num == 4) {
+      feature_diversity == DIVERSITY_TX2_RX1;
+    }
+    else if (at_num == 0) {
       radio_set_diversity(DIVERSITY_ENABLED);
     }
     at_ok();

--- a/Firmware/radio/main.c
+++ b/Firmware/radio/main.c
@@ -100,6 +100,7 @@ bool feature_golay;
 bool feature_opportunistic_resend;
 uint8_t feature_mavlink_framing;
 bool feature_rtscts;
+uint8_t feature_diversity;
 
 void
 main(void)
@@ -124,6 +125,7 @@ main(void)
 	feature_opportunistic_resend = param_get(PARAM_OPPRESEND)?true:false;
 	feature_golay = param_get(PARAM_ECC)?true:false;
 	feature_rtscts = param_get(PARAM_RTSCTS)?true:false;
+	feature_diversity = param_get(PARAM_DIVERSITY);
 
 	// Do hardware initialisation.
 	hardware_init();

--- a/Firmware/radio/parameters.c
+++ b/Firmware/radio/parameters.c
@@ -73,6 +73,7 @@ __code const struct parameter_info {
 #ifdef INCLUDE_AES
   {"ENCRYPTION_LEVEL", 0}, // no Enycryption (0), 128 or 256 bit key
 #endif
+  {"DIVERSITY", 0},
 };
 
 /// In-RAM parameter store.
@@ -166,6 +167,16 @@ param_check(__pdata enum ParamID id, __data uint32_t val)
 		if (val > 131)
 			return false;
 		break;
+		
+	case PARAM_DIVERSITY:
+        #ifdef RFD900_DIVERSITY
+         		if (val > 3)
+        			return false;
+        #else
+         		if (val != 0)
+        			return false;      
+        #endif	
+	    break;	
 
 	default:
 		// no sanity check for this value
@@ -218,6 +229,11 @@ param_set(__data enum ParamID param, __pdata param_t value)
 		feature_rtscts = value?true:false;
 		value = feature_rtscts?1:0;
 		break;
+
+	case PARAM_DIVERSITY:
+		feature_diversity = (uint8_t) value;
+		value = feature_diversity;
+	    break;	
 
 	default:
 		break;

--- a/Firmware/radio/parameters.h
+++ b/Firmware/radio/parameters.h
@@ -65,6 +65,7 @@ enum ParamID {
 #ifdef INCLUDE_AES
   PARAM_ENCRYPTION,     // no Enycryption (0), 128 or 256 bit key
 #endif
+	PARAM_DIVERSITY,       // 0 => no diversity, 1 => "auto antenna select for tx/rx", 2&3 => "manual" where one ant is TX only, and the other is RX only.
 	PARAM_MAX				// must be last
 };
 

--- a/Firmware/radio/radio.h
+++ b/Firmware/radio/radio.h
@@ -72,6 +72,8 @@ extern bool feature_golay;
 extern bool feature_opportunistic_resend;
 extern uint8_t feature_mavlink_framing;
 extern bool feature_rtscts;
+extern uint8_t feature_diversity;
+
 
 /// System clock frequency
 ///
@@ -302,10 +304,12 @@ extern int16_t radio_temperature(void);
 //-----------------------------------------------------------------------------
 enum DIVERSITY_Enum
 {
-  DIVERSITY_ENABLED = 0,          // 0x00
-  DIVERSITY_DISABLED,             // 0x01
-  DIVERSITY_ANT1,                 // 0x02
-  DIVERSITY_ANT2                  // 0x03
+  DIVERSITY_ENABLED = 0,          // 0x00  = autoselect antenna for tx/rx on the fly
+  DIVERSITY_DISABLED,             // 0x01  = fixed single-antenna systems
+  DIVERSITY_ANT1,                 // 0x02  = make a dual-antenna system act like it's only got "antenna 1", locking tx and rx  there.
+  DIVERSITY_ANT2,                 // 0x03  = opposite of the previous one - ie only use "antenna 2"
+  DIVERSITY_TX1_RX2,              // force all transmits to be on antenna1, and all recieves to be on antenna2  
+  DIVERSITY_TX2_RX1               // opposite of the previous one.
 };
 
 extern void radio_set_diversity(enum DIVERSITY_Enum state);


### PR DESCRIPTION
this ( compiles but untested) code in theory allows the operator to explicity control which antennas are used for what, such as either forcing all rx/tx thru a particular antenna, or separating rx and tx to different antennas. 
-  do not merge, for discussion only.
